### PR TITLE
Minor update

### DIFF
--- a/init.el
+++ b/init.el
@@ -194,13 +194,6 @@ passed in as an argument."
     (add-hook 'minibuffer-setup-hook #'setup-fast-minibuffer)
     (add-hook 'minibuffer-exit-hook #'close-fast-minibuffer)
 ;;;; Fonts
-    (when (and (find-font (font-spec :name "JetBrains Mono"))
-	       (find-font (font-spec :name "Cantarell"))
-	       (find-font (font-spec :name "iA Writer Quattro V")))
-        (set-face-attribute 'default nil :font "JetBrains Mono-12")
-        (set-face-attribute 'variable-pitch nil :font "Cantarell-12")
-	(setq buffer-face-mode-face '(:font "iA Writer Quattro V")))
-
     (set-display-table-slot
      standard-display-table
      'selective-display
@@ -609,6 +602,11 @@ passed in as an argument."
 	    "op"   #'pandoc-mode
 	    "o="   #'calc
 	    "ow"   #'scratch-window-toggle
+            "os" `(,(lambda () (interactive)
+                        (when current-prefix-arg 
+                            (select-frame (make-frame)))
+                        (funcall quake-term-preferred-command 'new))
+                   :wk "Open new shell")
 
 ;;;;;; Search
 	    "s"    '(nil :wk "search")
@@ -898,6 +896,7 @@ a flat list of the `define-key' expressions to set the text objects up."
 	:after (orderless)
         :hook ((prog-mode . corfu-mode)
 	       (shell-mode . corfu-mode)
+               (eshell-mode . corfu-mode)
 	       (minibuffer-setup . corfu-enable-in-minibuffer))
         ;; Optional customizations
         :custom

--- a/init.el
+++ b/init.el
@@ -819,19 +819,8 @@ a flat list of the `define-key' expressions to set the text objects up."
     (use-package treemacs
         :commands (treemacs)
         :config
-        (dolist (face '(treemacs-root-face
-                        treemacs-git-unmodified-face
-                        treemacs-git-modified-face
-                        treemacs-git-renamed-face
-                        treemacs-git-ignored-face
-                        treemacs-git-untracked-face
-                        treemacs-git-added-face
-                        treemacs-git-conflict-face
-                        treemacs-directory-face
-                        treemacs-directory-collapsed-face
-                        treemacs-file-face
-                        treemacs-tags-face))
-	    (set-face-attribute face nil :inherit 'variable-pitch :height 120)))
+        (dolist (face (custom-group-members 'treemacs-faces nil))
+	    (set-face-attribute (car face) nil :inherit 'variable-pitch :height 120)))
 
     (use-package treemacs-evil
         :after (treemacs evil)
@@ -1138,8 +1127,11 @@ in `denote-link'."
         :after (doom-themes)
         :config
         (spacious-padding-mode 1)
-        (set-face-attribute 'mode-line nil :inherit 'variable-pitch :height 120)
-        (set-face-attribute 'mode-line-inactive nil :inherit 'mode-line))
+        (defun quake/fix-fonts (frame)
+            (set-face-attribute 'mode-line frame :inherit 'variable-pitch :height 120)
+            (set-face-attribute 'mode-line-inactive frame :inherit 'mode-line))
+        (add-hook 'after-make-frame-functions #'quake/fix-fonts)
+        (quake/fix-fonts nil))
 
     ;; A super-fast modeline that also won't make me wish I didn't have eyes at least
     (use-package mood-line

--- a/init.el
+++ b/init.el
@@ -48,7 +48,7 @@
 
 ;; For more information, see the README in the online repository.
 
-;;; ====== Imported Packages======
+;;; ======Imported Packages======
 (require 'cl-lib)
 (require 'rx)
 
@@ -139,6 +139,8 @@ passed in as an argument."
     (global-set-key (kbd "<escape>") 'keyboard-escape-quit) ; people are used to ESC quitting things
     (setq eldoc-idle-delay 0.8)                   ; w/ eldoc-box/an LSP, idle delay is by default too distracting
     (setq display-line-numbers-width-start t)     ; when you open a file, set the width of the linum gutter to be large enough the whole file's line numbers
+    (setq-default indent-tabs-mode nil)           ; prefer spaces instead of tabs
+    (setq load-prefer-newer t)                    ; always prefer newer bytecode files
 ;;;;; Disabling ugly and largely unhelpful UI features 
     (menu-bar-mode -1)
     (tool-bar-mode -1)
@@ -151,6 +153,7 @@ passed in as an argument."
     (cua-mode t)                           ; Ctrl-C, Ctrl-V, etc
     (winner-mode 1)                        ; better window manipulation
     (recentf-mode 1)                       ; remember recent files
+    (save-place-mode 1)                    ; save your place in files
     (setq recentf-max-menu-items 25
           recentf-max-saved-items 25)
     (savehist-mode 1)                      ; remember commands

--- a/init.el
+++ b/init.el
@@ -175,6 +175,8 @@ passed in as an argument."
     (defun core/current-tab-name ()
 	(alist-get 'name (tab-bar--current-tab)))
 ;;;;; Performance tuning
+    (setq gc-cons-percentage 0.2
+          gc-cons-threshold (* 100 1024 1024))
 ;;;;;; Optimize font-locking for greater responsiveness
     (setq jit-lock-stealth-time 0.2
           jit-lock-defer-time 0.0
@@ -187,7 +189,7 @@ passed in as an argument."
     (defun setup-fast-minibuffer ()
         (setq gc-cons-threshold most-positive-fixnum))
     (defun close-fast-minibuffer ()
-        (setq gc-cons-threshold 800000))
+        (setq gc-cons-threshold (* 100 1024 1024)))
 
     (add-hook 'minibuffer-setup-hook #'setup-fast-minibuffer)
     (add-hook 'minibuffer-exit-hook #'close-fast-minibuffer)
@@ -195,10 +197,9 @@ passed in as an argument."
     (when (and (find-font (font-spec :name "JetBrains Mono"))
 	       (find-font (font-spec :name "Cantarell"))
 	       (find-font (font-spec :name "iA Writer Quattro V")))
-	(custom-set-faces
-	 '(default ((t (:height 120 :font "JetBrains Mono"))))
-	 '(variable-pitch ((t (:height 120 :font "Cantarell")))))
-	(setq buffer-face-mode-face '(:family "iA Writer Quattro V")))
+        (set-face-attribute 'default nil :font "JetBrains Mono-12")
+        (set-face-attribute 'variable-pitch nil :font "Cantarell-12")
+	(setq buffer-face-mode-face '(:font "iA Writer Quattro V")))
 
     (set-display-table-slot
      standard-display-table
@@ -251,9 +252,6 @@ passed in as an argument."
 ;;;; Minibuffer completion and searching improvement packages
     (use-package marginalia
         :after icomplete
-        :bind (:map minibuffer-local-map
-		    ("M-A" . marginalia-cycle))
-
         :init
         (marginalia-mode))
 


### PR DESCRIPTION
## Changes

The big win for this update is *massively* improved responsiveness and start times. I did a quick profile of Emacs's cpu usage while doing Eglot/corfu autocompletions, and it turned out 33% of the cpu time was being spent on *garbage collection*! Moreover, my start times had been steadily creeping up just past my target goal of 0.6s startup. So I went digging, and found out that according to the maintainers, the better variable to tweak isn't `gc-cons-threshold`, but `gc-cons-percentage`. According to one, the recommended value is "0.2 or so", so I set it to 0.2 and....

Holy smokes.

The entire UI was smoother and faster. Org mode opened *noticeably* faster. Files in general opened and font-locked faster. All of that could be dismissed as placebo, except the percentage of CPU time used up during a short completion session went from 33% to less than 3%, and that's 30% more time for Eglot during that window while it's doing completions. And if that isn't enough for you, start times went from 0.59-0.64 to 0.5-0.55. ***Seriously***.

Just for good measure, I also upped `gc-cons-threshold` from 8MB to 100MB, also in accordance with maintainer recommendations, and my start times went from 0.5-0.55 to 0.45-0.52 or so. A fair enough gain, if less substantial. The UI feels a bit snappier too.

In case you don't believe me, here's just a random startup I did right now, no prep:

![Screenshot from 2024-05-24 21-38-38](https://github.com/alexispurslane/quake-emacs/assets/1920151/ca8b958f-10e9-4685-8322-51afec8c4d84)

And the best part is, Emacs actually isn't using basically any more memory than it did before. It uses about 85MB idling on the dashboard for me, and about 160MB with a project open and LSP running.